### PR TITLE
fix: remove codecov from requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.1.0
     # via requests
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   pyjwt
     #   social-auth-core
@@ -24,6 +24,7 @@ django==3.2.18
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
+    #   social-auth-app-django
 idna==3.4
     # via requests
 oauthlib==3.2.2
@@ -38,7 +39,7 @@ pyjwt[crypto]==2.6.0
     #   social-auth-core
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2022.7.1
+pytz==2023.3
     # via django
 requests==2.28.2
     # via
@@ -48,9 +49,9 @@ requests-oauthlib==1.3.1
     # via social-auth-core
 six==1.16.0
     # via -r requirements/base.in
-social-auth-app-django==5.1.0
+social-auth-app-django==5.2.0
     # via -r requirements/base.in
-social-auth-core==4.4.0
+social-auth-core==4.4.1
     # via
     #   -r requirements/base.in
     #   social-auth-app-django

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,6 +1,5 @@
 # Requirements for running tests in CI
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,32 +4,20 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.2
-    # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.10.2
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.1
     # via tox
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -41,7 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,22 +12,17 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 build==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
 certifi==2022.12.7
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
 cffi==1.15.1
@@ -36,7 +31,6 @@ cffi==1.15.1
     #   cryptography
 charset-normalizer==3.1.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
 click==8.1.3
@@ -55,15 +49,11 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-codecov==2.1.12
-    # via -r requirements/ci.txt
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/test.txt
-    #   codecov
     #   pytest-cov
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -86,13 +76,14 @@ django==3.2.18
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
+    #   social-auth-app-django
 edx-lint==5.3.4
     # via -r requirements/test.txt
 exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-filelock==3.10.2
+filelock==3.11.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -106,7 +97,6 @@ httpretty==1.1.4
     # via -r requirements/test.txt
 idna==3.4
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
 iniconfig==2.0.0
@@ -142,7 +132,7 @@ oauthlib==3.2.2
     #   -r requirements/test.txt
     #   requests-oauthlib
     #   social-auth-core
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -154,9 +144,9 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -189,7 +179,7 @@ pyjwt[crypto]==2.6.0
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-pylint==2.17.1
+pylint==2.17.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -213,7 +203,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -230,7 +220,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   django
@@ -240,9 +230,7 @@ pyyaml==6.0
     #   code-annotations
 requests==2.28.2
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/test.txt
-    #   codecov
     #   pyjwkest
     #   requests-oauthlib
     #   social-auth-core
@@ -258,9 +246,9 @@ six==1.16.0
     #   pyjwkest
     #   tox
     #   unittest2
-social-auth-app-django==5.1.0
+social-auth-app-django==5.2.0
     # via -r requirements/test.txt
-social-auth-core==4.4.0
+social-auth-core==4.4.1
     # via
     #   -r requirements/test.txt
     #   social-auth-app-django
@@ -287,7 +275,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -312,7 +300,6 @@ unittest2==1.1.0
     # via -r requirements/test.txt
 urllib3==1.26.15
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
 virtualenv==20.21.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,9 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.40.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.0.1
     # via -r requirements/pip.in
-setuptools==67.6.0
+setuptools==67.6.1
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,12 +10,10 @@ asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via pytest
 certifi==2022.12.7
     # via
     #   -r requirements/base.txt
@@ -37,11 +35,11 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -58,11 +56,12 @@ distlib==0.3.6
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
+    #   social-auth-app-django
 edx-lint==5.3.4
     # via -r requirements/test.in
 exceptiongroup==1.1.1
     # via pytest
-filelock==3.10.2
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
@@ -93,13 +92,13 @@ oauthlib==3.2.2
     #   -r requirements/base.txt
     #   requests-oauthlib
     #   social-auth-core
-packaging==23.0
+packaging==23.1
     # via
     #   pytest
     #   tox
 pbr==5.11.1
     # via stevedore
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   pylint
     #   virtualenv
@@ -123,7 +122,7 @@ pyjwt[crypto]==2.6.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-pylint==2.17.1
+pylint==2.17.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -137,7 +136,7 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   pytest-cov
     #   pytest-django
@@ -151,7 +150,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.txt
     #   django
@@ -174,9 +173,9 @@ six==1.16.0
     #   pyjwkest
     #   tox
     #   unittest2
-social-auth-app-django==5.1.0
+social-auth-app-django==5.2.0
     # via -r requirements/base.txt
-social-auth-core==4.4.0
+social-auth-core==4.4.1
     # via
     #   -r requirements/base.txt
     #   social-auth-app-django
@@ -194,7 +193,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 tox==3.28.0
     # via


### PR DESCRIPTION
### Description
- Codecov deprecated the pypi package long ago (Feb 2022) but left it up until now.
- Removing the package from requirements to fix the failing upgrade job.
- The Github Action we use to upload to codecov doesn’t depend on the package so our CI coverage won’t be affected by the change.