### PR TITLE
docs: Update the contributing guidelines link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,10 +134,7 @@ How To Contribute
 
 Contributions are very welcome!
 
-Please read `How To Contribute <https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst>`_ for details.
-
-Even though it was written with `edx-platform <https://github.com/openedx/edx-platform>`_ in mind,
-the guidelines should be followed for Open edX code in general.
+Please read `How To Contribute <https://github.com/openedx/.github/blob/master/CONTRIBUTING.md>`_ for details.
 
 Reporting Security Issues
 -------------------------


### PR DESCRIPTION
We're moving towards a single set of guidelines org-wide.
