### PR TITLE
fix: remove tox-battery from requirements and update tox

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ cffi==1.16.0
     # via cryptography
 charset-normalizer==3.3.2
     # via requests
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   pyjwt
     #   social-auth-core
@@ -25,7 +25,7 @@ django==3.2.23
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
     #   social-auth-app-django
-idna==3.4
+idna==3.6
     # via requests
 oauthlib==3.2.2
     # via
@@ -52,7 +52,7 @@ six==1.16.0
     # via -r requirements/base.in
 social-auth-app-django==5.4.0
     # via -r requirements/base.in
-social-auth-core==4.5.0
+social-auth-core==4.5.1
     # via
     #   -r requirements/base.in
     #   social-auth-app-django

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,4 +2,3 @@
 -c constraints.txt
 
 tox                       # Virtualenv management for tests
-tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,10 +12,8 @@ filelock==3.13.1
     #   virtualenv
 packaging==23.2
     # via tox
-platformdirs==3.11.0
-    # via
-    #   -c requirements/common_constraints.txt
-    #   virtualenv
+platformdirs==4.1.0
+    # via virtualenv
 pluggy==1.3.0
     # via tox
 py==1.11.0
@@ -28,8 +26,5 @@ tox==3.28.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/ci.in
-    #   tox-battery
-tox-battery==0.6.2
-    # via -r requirements/ci.in
-virtualenv==20.24.7
+virtualenv==20.25.0
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -21,8 +21,3 @@ elasticsearch<7.14.0
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0
-
-# virtualenv latest version requires platformdirs<4.0 which conflicts with tox>4.0 version
-# This constraint can be removed once the issue 
-# https://github.com/pypa/virtualenv/issues/2666 gets resolved 
-platformdirs<4.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -54,7 +54,7 @@ coverage[toml]==7.3.2
     #   -r requirements/test.txt
     #   coverage
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -92,11 +92,11 @@ filelock==3.13.1
     #   virtualenv
 httpretty==1.1.4
     # via -r requirements/test.txt
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
@@ -143,9 +143,8 @@ pbr==6.0.0
     #   stevedore
 pip-tools==7.3.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
-    #   -c requirements/common_constraints.txt
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   pylint
@@ -241,7 +240,7 @@ six==1.16.0
     #   unittest2
 social-auth-app-django==5.4.0
     # via -r requirements/test.txt
-social-auth-core==4.5.0
+social-auth-core==4.5.1
     # via
     #   -r requirements/test.txt
     #   social-auth-app-django
@@ -278,9 +277,6 @@ tox==3.28.0
     #   -c requirements/constraints.txt
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
-    #   tox-battery
-tox-battery==0.6.2
-    # via -r requirements/ci.txt
 traceback2==1.4.0
     # via
     #   -r requirements/test.txt
@@ -297,12 +293,12 @@ urllib3==2.1.0
     # via
     #   -r requirements/test.txt
     #   requests
-virtualenv==20.24.7
+virtualenv==20.25.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   tox
-wheel==0.41.3
+wheel==0.42.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ build==1.0.3
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via build
 packaging==23.2
     # via build
@@ -21,7 +21,7 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-wheel==0.41.3
+wheel==0.42.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -39,7 +39,7 @@ coverage[toml]==7.3.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -67,7 +67,7 @@ filelock==3.13.1
     #   virtualenv
 httpretty==1.1.4
     # via -r requirements/test.in
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/base.txt
     #   requests
@@ -94,9 +94,8 @@ packaging==23.2
     #   tox
 pbr==6.0.0
     # via stevedore
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
-    #   -c requirements/common_constraints.txt
     #   pylint
     #   virtualenv
 pluggy==1.3.0
@@ -169,7 +168,7 @@ six==1.16.0
     #   unittest2
 social-auth-app-django==5.4.0
     # via -r requirements/base.txt
-social-auth-core==4.5.0
+social-auth-core==4.5.1
     # via
     #   -r requirements/base.txt
     #   social-auth-app-django
@@ -207,5 +206,5 @@ urllib3==2.1.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==20.24.7
+virtualenv==20.25.0
     # via tox


### PR DESCRIPTION
## Description
- Removed `tox-battery` from requirements since it is not needed with `tox v4` anymore.
- Updated `tox` to `v4`.