### PR TITLE
Fix and enhance get_user_if_exists pipeline function with debugging capabilities.

### DIFF
--- a/auth_backends/pipeline.py
+++ b/auth_backends/pipeline.py
@@ -22,25 +22,143 @@ User = get_user_model()
 # .. toggle_target_removal_date: 2025-08-18
 SKIP_UPDATE_EMAIL_ON_USERNAME_MISMATCH = SettingToggle("SKIP_UPDATE_EMAIL_ON_USERNAME_MISMATCH", default=False)
 
+# .. toggle_name: DEBUG_GET_USER_IF_EXISTS
+# .. toggle_implementation: SettingToggle
+# .. toggle_default: False
+# .. toggle_description: Enables detailed debugging and monitoring for the get_user_if_exists pipeline function.
+#    When enabled (True), additional logging and custom attributes will be set to help debug
+#    user account conflicts and authentication issues.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2025-07-23
+# .. toggle_target_removal_date: 2025-09-23
+DEBUG_GET_USER_IF_EXISTS = SettingToggle("DEBUG_GET_USER_IF_EXISTS", default=False)
+
 
 # pylint: disable=unused-argument
 # The function parameters must be named exactly as they are below.
 # Do not change them to appease Pylint.
 def get_user_if_exists(strategy, details, user=None, *args, **kwargs):  # pylint: disable=keyword-arg-before-vararg
-    """Return a User with the given username iff the User exists."""
+    """Return a User with the given username iff the User exists.
+
+    Enhanced with debugging capabilities to track user account conflicts and authentication issues.
+    """
+    details_username = details.get('username')
+
+    # Set custom attributes for debugging
+    # .. custom_attribute_name: get_user_if_exists.details_username
+    # .. custom_attribute_description: Records the username provided in the social details
+    #    to help debug authentication and user lookup issues.
+    set_custom_attribute('get_user_if_exists.details_username', details_username)
+
+    # .. custom_attribute_name: get_user_if_exists.user_provided
+    # .. custom_attribute_description: Indicates whether a user object was already provided
+    #    to the pipeline function, which affects the lookup logic.
+    set_custom_attribute('get_user_if_exists.user_provided', user is not None)
+
+    # .. custom_attribute_name: get_user_if_exists.debug_enabled
+    # .. custom_attribute_description: Tracks whether the DEBUG_GET_USER_IF_EXISTS
+    #    toggle is enabled during this pipeline execution.
+    set_custom_attribute('get_user_if_exists.debug_enabled', DEBUG_GET_USER_IF_EXISTS.is_enabled())
+
     if user:
+        # User is already provided - this typically happens when user exists from previous pipeline steps
+        existing_username = getattr(user, 'username', None)
+
+        # .. custom_attribute_name: get_user_if_exists.existing_user_username
+        # .. custom_attribute_description: Records the username of the existing user object
+        #    when a user is already provided to the pipeline.
+        set_custom_attribute('get_user_if_exists.existing_user_username', existing_username)
+
+        # Check for username mismatch between provided user and details
+        username_mismatch = details_username != existing_username
+
+        # .. custom_attribute_name: get_user_if_exists.username_mismatch
+        # .. custom_attribute_description: Tracks whether there's a mismatch between
+        #    the username in details and the existing user's username.
+        set_custom_attribute('get_user_if_exists.username_mismatch', username_mismatch)
+
+        if DEBUG_GET_USER_IF_EXISTS.is_enabled() or username_mismatch:
+            logger.info(
+                "get_user_if_exists: User already provided. Username mismatch: %s. "
+                "Details username: %s, Existing user username: %s",
+                username_mismatch,
+                details_username,
+                existing_username
+            )
+
+        if username_mismatch:
+            logger.warning(
+                "Username mismatch in get_user_if_exists. Details username: %s, "
+                "Existing user username: %s. This may indicate an authentication issue.",
+                details_username,
+                existing_username
+            )
+
         return {'is_new': False}
+
+    # No user provided, attempt to find user by username from details
+    if not details_username:
+        logger.warning("get_user_if_exists: No username provided in details")
+        # .. custom_attribute_name: get_user_if_exists.no_username_in_details
+        # .. custom_attribute_description: Indicates that no username was provided in the details,
+        #    which may indicate an issue with the authentication provider.
+        set_custom_attribute('get_user_if_exists.no_username_in_details', True)
+        return {}
+
     try:
-        username = details.get('username')
+        found_user = User.objects.get(username=details_username)
+
+        # .. custom_attribute_name: get_user_if_exists.user_found
+        # .. custom_attribute_description: Indicates that a user was successfully found
+        #    by username lookup in the database.
+        set_custom_attribute('get_user_if_exists.user_found', True)
+
+        # .. custom_attribute_name: get_user_if_exists.found_user_id
+        # .. custom_attribute_description: Records the ID of the user found by username lookup
+        #    to help track user account conflicts.
+        set_custom_attribute('get_user_if_exists.found_user_id', found_user.id)
+
+        if DEBUG_GET_USER_IF_EXISTS.is_enabled():
+            logger.info(
+                "get_user_if_exists: Found existing user with username '%s' (ID: %s)",
+                details_username,
+                found_user.id
+            )
 
         # Return the user if it exists
         return {
             'is_new': False,
-            'user': User.objects.get(username=username)
+            'user': found_user
         }
     except User.DoesNotExist:
-        # Fall to the default return value
-        pass
+        # .. custom_attribute_name: get_user_if_exists.user_found
+        # .. custom_attribute_description: Indicates that no user was found
+        #    by username lookup in the database.
+        set_custom_attribute('get_user_if_exists.user_found', False)
+
+        if DEBUG_GET_USER_IF_EXISTS.is_enabled():
+            logger.info(
+                "get_user_if_exists: No user found with username '%s'",
+                details_username
+            )
+
+    except Exception as e:
+        # Handle any unexpected errors during user lookup
+        logger.error(
+            "get_user_if_exists: Unexpected error during user lookup for username '%s': %s",
+            details_username,
+            str(e)
+        )
+
+        # .. custom_attribute_name: get_user_if_exists.lookup_error
+        # .. custom_attribute_description: Indicates that an unexpected error occurred
+        #    during user lookup, which may indicate database or system issues.
+        set_custom_attribute('get_user_if_exists.lookup_error', True)
+
+        # .. custom_attribute_name: get_user_if_exists.error_message
+        # .. custom_attribute_description: Records the error message when an unexpected
+        #    error occurs during user lookup.
+        set_custom_attribute('get_user_if_exists.error_message', str(e))
 
     # Nothing to return since we don't have a user
     return {}


### PR DESCRIPTION
### Description:

The `get_user_if_exists` function lacks visibility into authentication failures. We can't debug why "user already exists" errors happen in devstack but not in stage.

### Solution:

- **Added comprehensive debugging** with new toggle `DEBUG_GET_USER_IF_EXISTS`.

- **Added custom attributes** to track authentication flow and detect issues:

          - Username mismatches between details and existing users.
          - User lookup success/failure states.
          - Database errors during user retrieval.

- **Improved logging** with detailed info and warning messages.

- **Removed unnecessary** `pass` statement for cleaner code.

### JIRA Ticket:

[BOMS-3](https://2u-internal.atlassian.net/browse/BOMS-3)

### Reference PR:

[PR](https://github.com/openedx/auth-backends/pull/382)
