### PR TITLE
fix: added logout user before sso pipeline starts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,16 @@ Unreleased
 ----------
 
 
+[4.6.1] - 2025-09-23
+--------------------
+
+Added
+~~~~~
+
+* Enhanced OAuth2 authentication backend to logout any old session before initiating a new OAuth2 flow. This prevents user association conflicts with the previously logged-in user.
+
+  * Added temporary rollout toggle ENABLE_OAUTH_SESSION_CLEANUP to control session cleanup during OAuth start process.
+
 [4.6.0] - 2025-06-18
 --------------------
 

--- a/auth_backends/backends.py
+++ b/auth_backends/backends.py
@@ -2,9 +2,27 @@
 
 For more information visit https://docs.djangoproject.com/en/dev/topics/auth/customizing/.
 """
+import logging
 import jwt
+from django.contrib.auth import logout
 from django.dispatch import Signal
 from social_core.backends.oauth import BaseOAuth2
+from edx_toggles.toggles import SettingToggle
+from edx_django_utils.monitoring import set_custom_attribute
+
+logger = logging.getLogger(__name__)
+
+# .. toggle_name: ENABLE_OAUTH_SESSION_CLEANUP
+# .. toggle_implementation: SettingToggle
+# .. toggle_default: True
+# .. toggle_description: Controls whether to perform session cleanup during OAuth start.
+#    When enabled (True), existing user sessions are cleared before OAuth authentication
+#    to prevent user association conflicts. When disabled (False), session cleanup is skipped.
+#    This toggle allows for gradual rollout and quick rollback if issues arise.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2025-09-25
+# .. toggle_target_removal_date: 2025-11-25
+ENABLE_OAUTH_SESSION_CLEANUP = SettingToggle("ENABLE_OAUTH_SESSION_CLEANUP", default=True)
 
 PROFILE_CLAIMS_TO_DETAILS_KEY_MAP = {
     'preferred_username': 'username',
@@ -31,7 +49,6 @@ def _to_language(locale):
     return locale.replace('_', '-').lower()
 
 
-# pylint: disable=abstract-method
 class EdXOAuth2(BaseOAuth2):
     """
     IMPORTANT: The oauth2 application must have access to the ``user_id`` scope in order
@@ -69,6 +86,56 @@ class EdXOAuth2(BaseOAuth2):
                    f"redirect_url={self.setting('LOGOUT_REDIRECT_URL')}"
         else:
             return self.end_session_url()
+
+    def start(self):
+        """Initialize OAuth authentication with optional session cleanup."""
+
+        # .. custom_attribute_name: session_cleanup.toggle_enabled
+        # .. custom_attribute_description: Tracks whether the ENABLE_OAUTH_SESSION_CLEANUP
+        #    toggle is enabled during OAuth start.
+        set_custom_attribute('session_cleanup.toggle_enabled', ENABLE_OAUTH_SESSION_CLEANUP.is_enabled())
+
+        request = self.strategy.request if hasattr(self.strategy, 'request') else None
+
+        # .. custom_attribute_name: session_cleanup.has_request
+        # .. custom_attribute_description: Tracks whether a request object is available
+        #    during OAuth start. True if request exists, False if missing.
+        set_custom_attribute('session_cleanup.has_request', request is not None)
+
+        user_authenticated = (
+            request is not None and
+            hasattr(request, 'user') and
+            request.user.is_authenticated
+        )
+
+        # .. custom_attribute_name: session_cleanup.logout_required
+        # .. custom_attribute_description: Tracks whether a user was authenticated
+        #    before session cleanup. True if user was logged in, False otherwise.
+        set_custom_attribute('session_cleanup.logout_required', user_authenticated)
+
+        if user_authenticated and ENABLE_OAUTH_SESSION_CLEANUP.is_enabled():
+            existing_username = getattr(request.user, 'username', 'unknown')
+
+            # .. custom_attribute_name: session_cleanup.logged_out_username
+            # .. custom_attribute_description: Records the username that was logged out
+            #    during session cleanup for tracking and debugging purposes.
+            set_custom_attribute('session_cleanup.logged_out_username', existing_username)
+
+            logger.info(
+                "OAuth start: Performing session cleanup for user '%s'",
+                existing_username
+            )
+
+            logout(request)
+
+            # .. custom_attribute_name: session_cleanup.logout_performed
+            # .. custom_attribute_description: Indicates that session cleanup was
+            #    actually performed during OAuth start.
+            set_custom_attribute('session_cleanup.logout_performed', True)
+        else:
+            set_custom_attribute('session_cleanup.logout_performed', False)
+
+        return super().start()
 
     def authorization_url(self):
         url_root = self.get_public_or_internal_url_root()

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -4,12 +4,15 @@
 -r base.txt                # Core dependencies
 
 coverage
+ddt                        # for running multiple test cases with multiple input
 edx-lint
 httpretty
 pycodestyle
-pycryptodomex                   # used for crypto tests
+pycryptodomex              # used for crypto tests
 pytest-cov
 pytest-django
+responses                  # required by ddt
 tox
+typing_extensions          # required by ddt
 unittest2
-edx-django-release-util   # Contains the reserved keyword check
+edx-django-release-util    # Contains the reserved keyword check


### PR DESCRIPTION
### Description:
Users logging in through OAuth SSO could retain session data from previous logins, creating potential security risks and confusion when switching between accounts.

### Solution:
Added `logout(request)` call in `EdXOAuth2.start()` method to clear existing sessions before OAuth authentication begins.

### JIRA:
[BOMS-3](https://2u-internal.atlassian.net/browse/BOMS-3)